### PR TITLE
SqrSNRGeometricFactorHist: full caching of P(R^2) histograms

### DIFF
--- a/src/statistics/ChiSquare_pdf.m
+++ b/src/statistics/ChiSquare_pdf.m
@@ -85,7 +85,7 @@ function p = ChiSquare_pdf(x, k, lambda=0)
 
     ## approximate by normal distribution if chi^2 failed
     kk = ii & ( !isfinite(logp_ts) | (logp_ts > 0) );
-    if any(kk)
+    if any(kk(:))
       p(kk) = normpdf(x(kk), k(kk) + lambda(kk), sqrt( 2.* ( k(kk) + 2.*lambda(kk) ) ));
       normal_approx = 1;
     endif


### PR DESCRIPTION
- extends Christoph's idea of 1-result buffering to full caching of
  all previous results
- uses $HOME/.cache/octapps/SqrSNRGeometricFactorHist/ for storing
  cached results, using a hashed key of input parameters
- adds a test function comparing cached and non-cached result

@christoph30