### PR TITLE
WIP: Extensions and restructuring of sensitivity estimation

### DIFF
--- a/src/cw-sensitivity/SensitivityDepthBayesian.m
+++ b/src/cw-sensitivity/SensitivityDepthBayesian.m
@@ -1,0 +1,232 @@
+## Copyright (C) 2016, 2017 Christoph Dreissigacker
+## Copyright (C) 2011, 2016 Karl Wette
+##
+## This program is free software; you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation; either version 2 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with with program; see the file COPYING. If not, write to the
+## Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+## MA  02111-1307  USA
+
+## Calculate sensitivity in terms of the sensitivity depth.
+## Syntax:
+##   Depth = SensitivityDepthBayesian("opt", val, ...)
+## where:
+##   Depth    = SensitivityDepth
+##   pd_Depth = calculated false dismissal probability
+## and where options are:
+##   "pd"     = false dismissal probability
+##   "Ns"     = number of segments
+##   "Tdata"  = total amount of data used in seconds
+##   "Rsqr"   = histogram of SNR "geometric factor" R^2,
+##              computed using SqrSNRGeometricFactorHist(),
+##              or scalar giving mean value of R^2
+##   "stat"   = detection statistic, one of:
+##              * {"ChiSqr", "opt", val, ...}
+##                  chi^2 statistic, e.g. the F-statistic, see
+##                  SensitivityChiSqrFDP() for options
+##              * {"HoughFstat", "opt", val, ...}
+##                  Hough on the F-statistic, see
+##                  SensitivityHoughFstatFDP() for options
+##   "prog"   = show progress updates
+##  "misHist" = mismatch histograms (default: no mismatch)
+function Depth = SensitivityDepthBayesian(varargin)
+
+  ## parse options
+  parseOptions(varargin,
+	       {"pd", "real,strictunit,column"},
+	       {"Ns", "integer,strictpos,matrix"},
+	       {"Tdata","real, matrix"},
+	       {"Rsqr", "a:Hist", []},
+	       {"misHist","acell:Hist", []},
+	       {"stat", "cell,vector"},
+	       {"prog", "logical,scalar", false},
+	       []);
+  assert(histDim(Rsqr) == 1, "%s: R^2 must be a 1D histogram", funcName);                 #add for mismatch
+  assert(length(stat) > 1 && ischar(stat{1}), "%s: first element of 'stat' must be a string", funcName);
+  assert(isempty(misHist) || size(Ns,2) == length(misHist),"#stages unclear, #columns in Nseg must match #mismatch histograms.\n");
+
+  ## detect number of stages
+  stages = size(Ns,2);
+
+  ## select a detection statistic, we don't want to change the vector pd because here the columns are still the different stages
+  ## but there is only one overall pd for all stages
+  switch stat{1}
+    case "ChiSqr"   ## chi^2 statistic
+      [xx, Ns, FDP, fdp_vars, fdp_opts] = SensitivityChiSqrFDPBayes(pd(:,ones(size(Ns,2),1)), Ns, stat(2:end));
+%    case "HoughFstat"   ## Hough on F-statistic
+%      [xx, Ns, FDP, fdp_vars, fdp_opts] = SensitivityHoughFstatFDP(pd(:,ones(size(Ns,2),1)), Ns, stat(2:end));
+    otherwise
+      error("%s: invalid detection statistic '%s'", funcName, stat{1});
+  endswitch
+
+  ## bring Tdata to the same size as Ns
+  try
+    [cserr,Tdata,Ns] = common_size(Tdata,Ns);
+    assert(cserr == 0);
+  catch
+    if size(Ns,1) == size(Tdata,1)
+      Tdata = Tdata(:,ones(size(Ns,2),1));
+    elseif size(Ns,2) == size(Tdata,2)
+      Tdata = Tdata(ones(size(Ns,1),1),:);
+    else
+      error("Sizes of Tdata and Ns are not compatible\n");
+    endif
+  end_try_catch
+  ##transform Ns, Tdata and sa into a cell array
+  Ns = num2cell(Ns,1);
+  Tdata = num2cell(Tdata,1);
+  fdp_vars{1} = num2cell(fdp_vars{1},1);
+  if length(fdp_vars) > 1
+    fdp_vars{2} = num2cell(fdp_vars{2},1);
+  endif
+
+
+  ## get probability densities and bin quantities
+  Rsqr_px = histProbs(Rsqr);
+  [Rsqr_x, Rsqr_dx] = histBins(Rsqr, 1, "centre", "width");
+
+  ## check histogram bins are positive and contain no infinities                  # add for mismatch
+  if min(histRange(Rsqr)) < 0
+    error("%s: R^2 histogram bins must be positive", funcName);
+  endif
+  if Rsqr_px(1) > 0 || Rsqr_px(end) > 0
+    error("%s: R^2 histogram contains non-zero probability in infinite bins", funcName);
+  endif
+
+  ## chop off infinite bins and resize to row vectors, i.e. the bin values are enumerated by columns
+  Rsqr_px = reshape(Rsqr_px(2:end-1), 1, []);
+  Rsqr_x = reshape(Rsqr_x(2:end-1), 1, []);
+  Rsqr_dx = reshape(Rsqr_dx(2:end-1), 1, []);
+
+  ## compute weights
+  Rsqr_w = Rsqr_px .* Rsqr_dx;
+  clear Rsqr_px Rsqr_dx;
+
+  ## make row indexes logical, to select rows
+  ii = true(size(Ns{1}), 1);
+  ## make column indexes ones, to duplicate columns
+  jj = ones(length(Rsqr_x), 1);
+
+  if isempty(misHist)
+
+    ## assume no mismatch
+    mism_x = {};
+    mism_w = {};
+    mism_x(1:stages) = 0;
+    mism_w(1:stages) = 1;
+
+    kk = {};
+    kk(1:stages) = 1;
+    for i = 1:length(mism_x)
+      ## copy values along trials dimension,  ii + 0 converts logical into double       ## copying in higher dimensions happens later
+      mism_x{i} = mism_x{i}(ii + 0,:,:);
+      mism_w{i} = mism_w{i}(ii + 0,:,:);
+    endfor
+
+  else
+    ## transform a single mismatch histogram into a cell array
+    if isa(misHist,"Hist")
+      misHist = {misHist};
+    endif
+    ## get probabilitiy densities for mismatch
+    mism_px = cellfun(@histProbs,misHist,"UniformOutput",false);
+    [mism_x, mism_dx] = cellfun(@histBins,misHist, {1}, {"centre"}, {"width"},"UniformOutput",false);
+
+    ## chop off infinite bins and resize to vectors in different dimensions
+    for i = 1: length(mism_x)
+      mism_px{i} = reshape(mism_px{i}(2:end -1), 1,1,[]);
+      mism_x{i} = reshape(mism_x{i}(2:end -1), 1,1,[]);
+      mism_dx{i} = reshape(mism_dx{i}(2:end -1), 1,1,[]);
+
+      ## copy values along trials dimension,  ii + 0 converts logical into double       ## copying in higher dimensions happens later
+      mism_px{i} = mism_px{i}(ii + 0,:,:);
+      mism_x{i} = mism_x{i}(ii + 0,:,:);
+      mism_dx{i} = mism_dx{i}(ii + 0,:,:);
+
+    endfor
+
+    ## make indices for every remaining dimension ones, to duplicate them
+    kk = cellfun(@size,mism_x,{3},"UniformOutput",false);
+    kk = cellfun(@ones,kk,{1},"UniformOutput",false);
+
+    mism_w = cellfun('times',mism_px,mism_dx,"UniformOutput",false);
+    clear mism_px mism_dx;
+  endif
+
+  ## if pd should be constant along different trials copy it for each trial
+  if isscalar(pd)
+    pd = pd(ii + 0);
+  endif
+
+  ## show progress updates?
+  if prog
+    old_pso = page_screen_output(0);
+    printf("%s: starting\n", funcName);
+  endif
+
+  ## Depth is computed for each pd and Ns (dim. 1) by summing
+  ## false dismissal probability for fixed Rsqr_x, weighted
+  ## by Rsqr_w (dim. 2)
+  ## copy values along trials dimension
+  Rsqr_x = Rsqr_x(ii + 0, :);
+  Rsqr_w = Rsqr_w(ii + 0, :);
+
+  ## initialise variables
+  Depth = nan(length(ii), 1);
+  points = 2000;
+  invDepthRange = linspace(0, 1,points + 1)(2:end);
+  pdf_Depth = [];
+  for d = 1:length(invDepthRange)
+    invDepth = invDepthRange(d).*ones(size(Depth));
+    pdf_Depth(:,d) = callFDP(1./invDepth,ii,
+           jj,kk,Ns, Tdata,Rsqr_x,Rsqr_w,mism_x, mism_w,
+           FDP,fdp_vars,fdp_opts);
+  endfor
+%%  plot(invDepthRange,pdf_Depth)
+  Norm = sum(pdf_Depth,2);
+  cumDepth = cumsum(pdf_Depth,2);
+  [xx, Depth_i] = min(abs(cumDepth./Norm -(1 -pd)),[],2);
+  Depth = 1./(invDepthRange(:,Depth_i));
+%  plotHist(hist_Depth{1})
+%  Norm = cellfun(@quantileFuncOfHist,hist_Depth,{1})
+%  preDepth = cellfun(@quantileFuncOfHist,hist_Depth,{1-pd})
+%  Depth = 1./(cellfun(@quantileFuncOfHist,hist_Depth,{1-pd})./Norm);
+
+  ## display progress updates?
+  if prog
+    printf("%s: done\n", funcName);
+    page_screen_output(old_pso);
+  endif
+endfunction
+
+## call a false dismissal probability calculation equation
+function pd_Depth = callFDP(Depth,ii,
+			  jj,kk,Ns, Tdata,Rsqr_x,Rsqr_w,mism_x, mism_w,
+			  FDP,fdp_vars,fdp_opts)
+  if any(ii)
+    for i = 1:length(mism_x)
+      ##integrating over the mismatch distributions
+      pdfs(:,:,i) = sum((feval(FDP,Ns{i}(ii,jj,kk{i}),                       ## lower dimensional arrays are copied to the remaining dimensions
+		       (2 / 5 .*sqrt(Tdata{i}(ii,jj,kk{i}) ./Ns{i}(ii,jj,kk{i}))./Depth(ii,jj,kk{i})).^2 .*Rsqr_x(ii,:,kk{i}).*(1 - mism_x{i}(ii,jj,:)), ## might be better to do that before the loop
+		       cellfun(@(x) x{i}(ii,jj,kk{i}),fdp_vars,"UniformOutput",false),
+		       fdp_opts )) .*mism_w{i}(ii,jj,:),3);
+    endfor
+    ## product of the mismatch integrals, integration over R^2
+    pd_Depth = sum(prod(pdfs,3).* Rsqr_w(ii,:) , 2);
+  else
+    pd_Depth = [];
+  endif
+endfunction
+
+%!test
+%! Rsqr = SqrSNRGeometricFactorHist;
+%! Depth = SensitivityDepthBayesian ( "pd", 0.1, "Ns", 10, "Tdata", 10*86400, "Rsqr", Rsqr, "misHist", createDeltaHist(0.1), "stat", { "ChiSqr", "paNt", 1e-10 } );

--- a/src/cw-sensitivity/SensitivityDepthBayesian.m
+++ b/src/cw-sensitivity/SensitivityDepthBayesian.m
@@ -42,14 +42,14 @@ function Depth = SensitivityDepthBayesian(varargin)
 
   ## parse options
   parseOptions(varargin,
-	       {"pd", "real,strictunit,column"},
-	       {"Ns", "integer,strictpos,matrix"},
-	       {"Tdata","real, matrix"},
-	       {"Rsqr", "a:Hist", []},
-	       {"misHist","acell:Hist", []},
-	       {"stat", "cell,vector"},
-	       {"prog", "logical,scalar", false},
-	       []);
+               {"pd", "real,strictunit,column"},
+               {"Ns", "integer,strictpos,matrix"},
+               {"Tdata","real, matrix"},
+               {"Rsqr", "a:Hist", []},
+               {"misHist","acell:Hist", []},
+               {"stat", "cell,vector"},
+               {"prog", "logical,scalar", false},
+               []);
   assert(histDim(Rsqr) == 1, "%s: R^2 must be a 1D histogram", funcName);                 #add for mismatch
   assert(length(stat) > 1 && ischar(stat{1}), "%s: first element of 'stat' must be a string", funcName);
   assert(isempty(misHist) || size(Ns,2) == length(misHist),"#stages unclear, #columns in Nseg must match #mismatch histograms.\n");
@@ -182,24 +182,55 @@ function Depth = SensitivityDepthBayesian(varargin)
 
   ## initialise variables
   Depth = nan(length(ii), 1);
-  points = 2000;
-  invDepthRange = linspace(0, 1,points + 1)(2:end);
   pdf_Depth = [];
-  for d = 1:length(invDepthRange)
-    invDepth = invDepthRange(d).*ones(size(Depth));
-    pdf_Depth(:,d) = callFDP(1./invDepth,ii,
-           jj,kk,Ns, Tdata,Rsqr_x,Rsqr_w,mism_x, mism_w,
-           FDP,fdp_vars,fdp_opts);
-  endfor
-%%  plot(invDepthRange,pdf_Depth)
-  Norm = sum(pdf_Depth,2);
-  cumDepth = cumsum(pdf_Depth,2);
+
+  ## calculate first pdf
+  maxDepth = 1;
+  DepthRange = 1;
+  linDepth = DepthRange.*ones(size(Depth));
+  pdf_Depth(:,1) = callFDP(linDepth,ii,
+                              jj,kk,Ns, Tdata,Rsqr_x,Rsqr_w,mism_x, mism_w,
+                              FDP,fdp_vars,fdp_opts);
+  Norm = 1;
+  do
+    oldNorm = Norm;
+    maxDepth +=1;
+    DepthRange = linspace(1,maxDepth,10*(maxDepth-1)+1);
+    for d = 1: 10
+      linDepth = DepthRange(end-10+d).*ones(size(Depth)); ## depth resolution 0.1
+      pdf_Depth(:,end+1) = callFDP(linDepth,ii,
+                                      jj,kk,Ns, Tdata,Rsqr_x,Rsqr_w,mism_x, mism_w,
+                                      FDP,fdp_vars,fdp_opts);
+    endfor
+
+    Norm = sum(pdf_Depth./DepthRange.^2,2);
+    if (Norm != 0) && (oldNorm != 0)
+      err = abs(Norm./oldNorm) - 1;
+    else
+      err = 1;
+    endif
+  until err < 1e-4
+  DepthRange = DepthRange(end:-1:1);
+  pdf_Depth = pdf_Depth(:,end:-1:1);
+  points = length(DepthRange)
+  # old implementation
+  ## points = 20000;
+  ## DepthRange = linspace(1, 2000,points)(end:-1:1);
+  ## pdf_Depth = [];
+
+  ## for d = 1:length(DepthRange)
+  ##   linDepth = DepthRange(d).*ones(size(Depth));
+  ##   pdf_Depth(:,d) = callFDP(linDepth,ii,
+  ##          jj,kk,Ns, Tdata,Rsqr_x,Rsqr_w,mism_x, mism_w,
+  ##          FDP,fdp_vars,fdp_opts);
+  ## endfor
+  ## Norm = sum(pdf_Depth./DepthRange.^2,2);
+
+  cumDepth = cumsum(pdf_Depth./DepthRange.^2,2);
   [xx, Depth_i] = min(abs(cumDepth./Norm -(1 -pd)),[],2);
-  Depth = 1./(invDepthRange(:,Depth_i));
-%  plotHist(hist_Depth{1})
-%  Norm = cellfun(@quantileFuncOfHist,hist_Depth,{1})
-%  preDepth = cellfun(@quantileFuncOfHist,hist_Depth,{1-pd})
-%  Depth = 1./(cellfun(@quantileFuncOfHist,hist_Depth,{1-pd})./Norm);
+  Depth = DepthRange(:,Depth_i)
+  hold off;plot(DepthRange,pdf_Depth(1,:)./DepthRange.^2)
+  hold on; line([Depth(1),Depth(1)],ylim(),"color","r")
 
   ## display progress updates?
   if prog
@@ -210,15 +241,15 @@ endfunction
 
 ## call a false dismissal probability calculation equation
 function pd_Depth = callFDP(Depth,ii,
-			  jj,kk,Ns, Tdata,Rsqr_x,Rsqr_w,mism_x, mism_w,
-			  FDP,fdp_vars,fdp_opts)
+                          jj,kk,Ns, Tdata,Rsqr_x,Rsqr_w,mism_x, mism_w,
+                          FDP,fdp_vars,fdp_opts)
   if any(ii)
     for i = 1:length(mism_x)
       ##integrating over the mismatch distributions
       pdfs(:,:,i) = sum((feval(FDP,Ns{i}(ii,jj,kk{i}),                       ## lower dimensional arrays are copied to the remaining dimensions
-		       (2 / 5 .*sqrt(Tdata{i}(ii,jj,kk{i}) ./Ns{i}(ii,jj,kk{i}))./Depth(ii,jj,kk{i})).^2 .*Rsqr_x(ii,:,kk{i}).*(1 - mism_x{i}(ii,jj,:)), ## might be better to do that before the loop
-		       cellfun(@(x) x{i}(ii,jj,kk{i}),fdp_vars,"UniformOutput",false),
-		       fdp_opts )) .*mism_w{i}(ii,jj,:),3);
+                       (2 / 5 .*sqrt(Tdata{i}(ii,jj,kk{i}) ./Ns{i}(ii,jj,kk{i}))./Depth(ii,jj,kk{i})).^2 .*Rsqr_x(ii,:,kk{i}).*(1 - mism_x{i}(ii,jj,:)), ## might be better to do that before the loop
+                       cellfun(@(x) x{i}(ii,jj,kk{i}),fdp_vars,"UniformOutput",false),
+                       fdp_opts )) .*mism_w{i}(ii,jj,:),3);
     endfor
     ## product of the mismatch integrals, integration over R^2
     pd_Depth = sum(prod(pdfs,3).* Rsqr_w(ii,:) , 2);

--- a/src/cw-sensitivity/SensitivityDepthNEW.m
+++ b/src/cw-sensitivity/SensitivityDepthNEW.m
@@ -1,0 +1,266 @@
+## Copyright (C) 2018 Christoph Dreissigacker
+##
+## This program is free software; you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation; either version 2 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with with program; see the file COPYING. If not, write to the
+## Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+## MA  02111-1307  USA
+
+## -*- texinfo -*-
+## @deftypefn {Function File} { [ @var{Depth}, @var{pd_Depth} ] =} SensitivityDepth ( @var{opt}, @var{val}, @dots{} )
+##
+## Calculate sensitivity in terms of the sensitivity depth.
+##
+## @heading Arguments
+##
+## @table @var
+## @item Depth
+## SensitivityDepth
+##
+## @item pd_Depth
+## calculated false dismissal probability
+##
+## @end table
+##
+## @heading Options
+##
+## @table @code
+## @item pd
+## false dismissal probability
+##
+## @item Ns
+## number of segments
+##
+## @item Tdata
+## total amount of data used in seconds
+##
+## @item Rsqr
+## histogram of SNR "geometric factor" R^2,
+## computed using @command{SqrSNRGeometricFactorHist()},
+## or scalar giving mean value of R^2
+##
+## @item stat
+## detection statistic, one of:
+## @table @asis
+## @item @{@code{ChiSqr}, @var{opt}, @var{val}, @dots{}@}
+## chi^2 statistic, e.g. the F-statistic, with options:
+## @table @var
+## @item paNt
+## false alarm probability per template
+##
+## @item sa
+## false alarm threshold
+##
+## @item dof
+## degrees of freedom per segment (default: 4)
+##
+## @item norm
+## use normal approximation to chi^2 (default: false)
+##
+## @end table
+##
+## @item @{@code{HoughFstat}, @var{opt}, @var{val}, @dots{}@}
+## Hough on the F-statistic, with options:
+## @table @var
+## @item paNt
+## false alarm probability per template
+##
+## @item nth
+## number count false alarm threshold
+##
+## @item Fth
+## F-statistic threshold per segment
+##
+## @item zero
+## use zeroth-order approximation (default: false)
+##
+## @end table
+##
+## @end table
+##
+## @item prog
+## show progress updates
+##
+## @item misHist
+## mismatch histograms (default: no mismatch)
+##
+## @end table
+##
+## @end deftypefn
+
+function [Depth, pd_Depth] = SensitivityDepthNEW(varargin)
+
+  ## parse options
+  parseOptions(varargin,
+               {"pd", "real,strictunit,column"},
+               {"Nseg", "integer,strictpos,matrix"},
+               {"Tdata","real, matrix"},
+               {"Rsqr", "a:Hist", []},
+               {"misHist","acell:Hist", []},
+               {"stat", "cell,vector"},
+               {"prog", "logical,scalar", false},
+	       {"Bayesian", "logical", false},
+               []);
+  assert(histDim(Rsqr) == 1, "%s: R^2 must be a 1D histogram", funcName);
+  assert(length(stat) > 1 && ischar(stat{1}), "%s: first element of 'stat' must be a string", funcName);
+  stat_num =[1:length(stat)](cellfun(@isnumeric, stat));
+  compatibleTrialInputs = common_size(pd(:,1),Nseg(:,1),Tdata(:,1),stat{stat_num}(:,1));
+  assert(!compatibleTrialInputs,"#trials unclear \n pd,Nseg,Tdata,pFA, threshold must either be scalar or the number of rows must be the #trials");
+  
+  ## check stages are well defined
+  assert(isempty(misHist) || size(Nseg,2) == size(misHist,2),
+	 "#stages unclear, #columns in Nsegeg must match #columns in mismatch histograms.\n");
+
+  stages = size(Nseg,2);
+  trials = max([size(pd,1),size(Nseg,1),size(Tdata,1),cellfun(@(x) size(x,2),stat(stat_num))]);
+  assert(!(Bayesian && stages >1),"Bayesian mode can only handle single stage searches");
+
+  ## ---- Preparations ----
+  
+  ## Bring all inputs to the proper size
+  ## 1. Dimension for different trials
+  ## 2. Dimension for different depth
+  ## 3. Dimension varying Rsqr
+  ## 4. Dimension varying Stat
+  ## 5. Dimension varying mismatch
+  
+
+  ## Copying index to increase dimension
+  TrialCI = ones(length(trials),1);
+  
+  ## stages are indexed as cell array
+  for i = 1:length(stat_num)
+    stat{stat_num(i)} = num2cell(stat{stat_num(i)},1);
+  endfor
+  Tdata = num2cell(Tdata,1);
+  Nseg = num2cell(Nseg,1);
+  
+  ## transform a single mismatch histogram into a cell array
+  if isa(misHist,"Hist")
+      misHist = {misHist};
+  endif
+  if isempty(misHist)
+    misHist = {createDeltaHist(0)};
+  endif
+  ## Extract values from misHists
+  ## get probabilitiy densities for mismatch
+  mism_px = cellfun(@histProbs,misHist,"UniformOutput",false);
+  [mism_x, mism_dx] = cellfun(@histBins,misHist, {1}, {"centre"}, {"width"},"UniformOutput",false);
+
+  mism_w = cellfun('times',mism_px,mism_dx,"UniformOutput",false);
+  clear mism_px mism_dx;
+
+ 
+  ## Extract values from Rsqr hist
+  Rsqr_px = histProbs(Rsqr);
+  [Rsqr_x, Rsqr_dx] = histBins(Rsqr, 1, "centre", "width");
+  ## check histogram bins are positive and contain no infinities
+  if min(histRange(Rsqr)) < 0
+    error("%s: R^2 histogram bins must be positive", funcName);
+  endif
+  if Rsqr_px(1) > 0 || Rsqr_px(end) > 0
+    error("%s: R^2 histogram contains non-zero probability in infinite bins", funcName);
+  endif
+  ## compute weights
+  Rsqr_w = Rsqr_px .* Rsqr_dx;
+  clear Rsqr_px Rsqr_dx;
+
+
+## check for trials with different misHists??
+
+  
+  ## logical index to select trial
+  TrialSI = true(trials, 1);
+
+  ## resize misHists
+  ## chop off infinite bins and resize to vectors in different dimensions
+  for i = 1: stages
+    mism_x{i} = reshape(mism_x{i}(2:end -1), 1,1,1,1,[]);
+    mism_w{i} = reshape(mism_w{i}(2:end -1), 1,1,1,1,[]);
+  endfor
+  ## chop off infinite bins and resize to row vectors, i.e. the bin values are enumerated by columns
+  Rsqr_x = reshape(Rsqr_x(2:end-1), 1,1, []);
+  Rsqr_w = reshape(Rsqr_w(2:end-1), 1,1, []);
+  
+  ## prepare P(stat|h_0, R^2) function according to stat
+  stati = stat;
+  for i=1:stages
+    ## select stage i in stat
+    stati{stat_num} = stati{stat_num}{i};
+    [calcPdet, calcPDF] = SensitivitySelectStat("Nseg", Nseg{i}, "stat", stati{1:end}, "mism_w", mism_w{i});
+  endfor
+
+
+  ## ---- Calculations ---- 
+  pkg load optim
+  if Bayesian
+    ## implementation of eq. 52 or StackSlide equivalent times integration factor 1/D^2
+    pdet = @(D) 1./D.^2.*calcConf(D,calcPdet,calcPDF,TrialSI,Tdata, Rsqr_x, Rsqr_w, mism_x,Bayesian);
+    oldnorm = inf;
+    maxDepth = 100;
+    ## check how far we must integrate for the normalisation factor
+    do
+      Norm = quadv(pdet,0.1,maxDepth,1e-10)
+      norm_err = abs(Norm - oldnorm)./Norm;
+      maxDepth *=2;
+      oldnorm = Norm;
+    until all(norm_err < 1e-5)
+    ## integrate depth
+    conf = @(D) pd -  quadv(pdet,D, maxDepth./2,1e-10)./Norm;
+    ## solve equation 55 for the Depth
+    ## currently here is an issue with vfzero only accepting the search interval as square matrices
+    [Depth,pd_Depth,info,output] = vfzero(conf,[0.1,10^4].*ones(length(TrialSI),1));
+    assert(info == 1, "Root finder failed!")
+  else
+    ## implementation of eq. 54
+    pdet = @(D) pd - calcConf(D,calcPdet,calcPDF,TrialSI, Tdata,Rsqr_x,Rsqr_w,mism_x,Bayesian);
+    ## solve equation 54 for the Depth
+    [Depth,pd_Depth,info,output] = vfzero(pdet,[0.1,10^4].*ones(length(TrialSI),1));
+    assert(info == 1, "Root finder failed!")
+  endif
+  
+endfunction
+	      
+
+      
+
+	      
+
+
+
+function pdet = calcConf(Depth,calcPdet,calcPDF,TrialSI, Tdata,Rsqr_x,Rsqr_w,mism_x,Bayesian)
+ 
+  ## only calculate something if there is a not yet done trial
+  if any(TrialSI)
+    stages = length(mism_x);
+    ## loop over stages
+    for i = 1:stages
+      ## calculate effective non centrality
+      rhosqr_eff{i}= Rhosqr_eff(Tdata{i},Depth, Rsqr_x, mism_x{i});
+    endfor
+    if Bayesian
+      ## eval calcPDF
+      pdf = feval(calcPDF,rhosqr_eff{1});
+      ## integrate over R2
+      pdet = sum(pdf.*Rsqr_w,3);
+    else
+      ## eval calcPdet
+      pdeti = cell2mat(cellfun(@feval,{calcPdet},rhosqr_eff,"UniformOutput",false));
+      ## prod over stages
+      pdet_tot = prod(pdeti,2);
+      ## integrate over R2
+      pdet = sum(pdet_tot.*Rsqr_w,3);
+    endif
+  else
+    pdf = [];
+  endif
+endfunction

--- a/src/cw-sensitivity/SensitivityDepthStackSlide.m
+++ b/src/cw-sensitivity/SensitivityDepthStackSlide.m
@@ -82,6 +82,10 @@
 ## @item delta
 ## source declination (default: all-sky)
 ##
+## @item Bayesian
+## if true, compute the sensitivity depth corresponding to a Bayesian upper limit, otherwise assume standard frequentist upper limit
+## (default: false)
+##
 ## @end table
 ##
 ## @heading Examples
@@ -104,6 +108,7 @@ function sensDepth = SensitivityDepthStackSlide ( varargin )
                         {"detweights", "real,strictpos,vector", []},
                         {"alpha", "real,vector", [0, 2*pi]},
                         {"delta", "real,vector", [-pi/2, pi/2]},
+                        {"Bayesian", "logical,scalar", false},
                         []);
 
   ## check input
@@ -122,7 +127,12 @@ function sensDepth = SensitivityDepthStackSlide ( varargin )
 
   ## compute sensitivity SNR
   Rsqr = SqrSNRGeometricFactorHist("detectors", uvar.detectors, "detweights", uvar.detweights, "alpha", uvar.alpha, "sdelta", sin(uvar.delta) );
-  [sensDepth, pd_Depth] = SensitivityDepth ( "pd", uvar.pFD, "Ns", uvar.Nseg, "Tdata",uvar.Tdata, "Rsqr", Rsqr,"misHist",uvar.misHist, "stat", {"ChiSqr", FAarg{:}} );
+
+  if !uvar.Bayesian
+    [sensDepth, pd_Depth] = SensitivityDepth ( "pd", uvar.pFD, "Ns", uvar.Nseg, "Tdata", uvar.Tdata, "Rsqr", Rsqr, "misHist", uvar.misHist, "stat", {"ChiSqr", FAarg{:}} );
+  else
+    sensDepth = SensitivityDepthBayesian ( "pd", uvar.pFD, "Ns", uvar.Nseg, "Tdata",uvar.Tdata, "Rsqr", Rsqr,"misHist",uvar.misHist, "stat", {"ChiSqr", FAarg{:}} );
+  endif
 
 endfunction
 

--- a/src/cw-sensitivity/private/Rhosqr_eff.m
+++ b/src/cw-sensitivity/private/Rhosqr_eff.m
@@ -1,0 +1,26 @@
+## Copyright (C) 2018 Christoph Dreissigacker
+##
+## This program is free software; you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation; either version 2 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with with program; see the file COPYING. If not, write to the
+## Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+## MA  02111-1307  USA
+
+## Helper function for SensitivityDepth()
+##
+## Calculate the effective non-centrality according to eq. 43 of LIGO-P1800198
+
+function rhosqr_eff = Rhosqr_eff(Tdata, Depth, Rsqr_x, mism_x = 0)
+
+  rhosqr_eff = ( 2 / 5 .*sqrt(Tdata)./Depth ).^2 .*Rsqr_x.*( 1 - mism_x );
+
+endfunction

--- a/src/cw-sensitivity/private/Rhosqr_eff.m
+++ b/src/cw-sensitivity/private/Rhosqr_eff.m
@@ -21,6 +21,6 @@
 
 function rhosqr_eff = Rhosqr_eff(Tdata, Depth, Rsqr_x, mism_x = 0)
 
-  rhosqr_eff = ( 2 / 5 .*sqrt(Tdata)./Depth ).^2 .*Rsqr_x.*( 1 - mism_x );
+  rhosqr_eff = ( 2 / 5 ./Depth ).^2.*Tdata .*Rsqr_x.*( 1 - mism_x );
 
 endfunction

--- a/src/cw-sensitivity/private/SensitivityChiSqrFDPBayes.m
+++ b/src/cw-sensitivity/private/SensitivityChiSqrFDPBayes.m
@@ -1,0 +1,137 @@
+## Copyright (C) 2011 Karl Wette
+##
+## This program is free software; you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation; either version 2 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with with program; see the file COPYING. If not, write to the
+## Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+## MA  02111-1307  USA
+
+## Helper function for SensitivityDepth:
+## Calculate the false dismissal probability of a chi^2 detection
+## statistic, such as the F-statistic
+## Options:
+##   "paNt" = false alarm probability per template
+##   "sa"   = false alarm threshold
+##   "dof"  = degrees of freedom per segment (default: 4)
+##   "norm" = use normal approximation to chi^2 (default: false)
+
+function [pd, Ns, FDP, fdp_vars, fdp_opts] = SensitivityChiSqrFDPBayes(pd, Ns, args)
+
+  FDP = @ChiSqrFDP;
+
+  ## options
+  parseOptions(args,
+               {"paNt", "real,strictunit,matrix", []},
+               {"sa", "real,strictpos,matrix", []},
+               {"dof", "real,strictpos,scalar", 4},
+               {"norm", "logical,scalar", false}
+               );
+  fdp_opts.dof = dof;
+  fdp_opts.norm = norm;
+
+  ## false alarm threshold
+  if !xor(isempty(paNt), isempty(sa))
+    error("%s: 'paNt' and 'sa' are mutually exclusive options", funcName);
+  endif
+  if !isempty(paNt)
+    [cserr, paNt, pd, Ns] = common_size(paNt, pd, Ns);
+    if cserr > 0
+      error("%s: paNt, pd, and Ns are not of common size", funcName);
+    endif
+    sa = invFalseAlarm_chi2(paNt, Ns.*dof);
+  else
+    [cserr, sa, pd, Ns] = common_size(sa, pd, Ns);
+    if cserr > 0
+      error("%s: sa, pd, and Ns are not of common size", funcName);
+    endif
+  endif
+
+  ## variables
+  fdp_vars{1} = sa;
+
+endfunction
+
+## calculate false dismissal probability
+function pd_rhosqr = ChiSqrFDP(Ns, rhosqr, fdp_vars, fdp_opts)
+
+  ## degrees of freedom per segment
+  nu = fdp_opts.dof;
+
+  ## false alarm threshold
+  sa = fdp_vars{1};
+
+  ## false dismissal probability
+  if fdp_opts.norm
+
+    ## use normal approximation
+    mean = Ns.*( nu + rhosqr );
+    stdv = sqrt( 2.*Ns .* ( nu + 2.*rhosqr ) );
+    pd_rhosqr = normpdf(sa, mean, stdv);
+
+  else
+
+    ## use non-central chi-sqr distribution
+    pd_rhosqr = ChiSquare_pdf(sa, Ns*nu, Ns.*rhosqr);
+
+  endif
+
+endfunction
+
+## Test sensitivity calculated for chi^2 statistic
+## against values calculated by Mathematica implementation
+
+## calculate Rsqr for isotropic signal population
+%!shared Rsqr
+%!  Rsqr = SqrSNRGeometricFactorHist;
+
+## test SNR depth against reference value depth0
+%!function __test_sens(Rsqr,paNt,pd,nu,Ns,depth0)
+%!  depth = SensitivityDepth("Tdata",86400*Ns,"pd",pd,"Ns",Ns,"Rsqr",Rsqr,"stat",{"ChiSqr","paNt",paNt,"dof",nu});
+%!  assert(abs(depth - depth0) < 1e-2 * abs(depth0));
+
+## tests
+%!test __test_sens(Rsqr,0.01,0.05,2,1,17.9751)
+%!test __test_sens(Rsqr,0.01,0.05,2,100,80.4602)
+%!test __test_sens(Rsqr,0.01,0.05,2,10000,269.687)
+%!test __test_sens(Rsqr,0.01,0.05,4,1,16.429)
+%!test __test_sens(Rsqr,0.01,0.05,4,100,68.8944)
+%!test __test_sens(Rsqr,0.01,0.05,4,10000,227.24)
+%!test __test_sens(Rsqr,0.01,0.1,2,1,20.5666)
+%!test __test_sens(Rsqr,0.01,0.1,2,100,89.3568)
+%!test __test_sens(Rsqr,0.01,0.1,2,10000,297.123)
+%!test __test_sens(Rsqr,0.01,0.1,4,1,18.6925)
+%!test __test_sens(Rsqr,0.01,0.1,4,100,76.3345)
+%!test __test_sens(Rsqr,0.01,0.1,4,10000,250.28)
+%!test __test_sens(Rsqr,1e-07,0.05,2,1,10.5687)
+%!test __test_sens(Rsqr,1e-07,0.05,2,100,55.9013)
+%!test __test_sens(Rsqr,1e-07,0.05,2,10000,193.411)
+%!test __test_sens(Rsqr,1e-07,0.05,4,1,10.0133)
+%!test __test_sens(Rsqr,1e-07,0.05,4,100,48.3342)
+%!test __test_sens(Rsqr,1e-07,0.05,4,10000,163.153)
+%!test __test_sens(Rsqr,1e-07,0.1,2,1,11.589)
+%!test __test_sens(Rsqr,1e-07,0.1,2,100,60.1536)
+%!test __test_sens(Rsqr,1e-07,0.1,2,10000,206.551)
+%!test __test_sens(Rsqr,1e-07,0.1,4,1,10.9521)
+%!test __test_sens(Rsqr,1e-07,0.1,4,100,51.9024)
+%!test __test_sens(Rsqr,1e-07,0.1,4,10000,174.182)
+%!test __test_sens(Rsqr,1e-12,0.05,2,1,8.29336)
+%!test __test_sens(Rsqr,1e-12,0.05,2,100,47.5524)
+%!test __test_sens(Rsqr,1e-12,0.05,2,10000,168.007)
+%!test __test_sens(Rsqr,1e-12,0.05,4,1,7.96925)
+%!test __test_sens(Rsqr,1e-12,0.05,4,100,41.3759)
+%!test __test_sens(Rsqr,1e-12,0.05,4,10000,141.831)
+%!test __test_sens(Rsqr,1e-12,0.1,2,1,8.97247)
+%!test __test_sens(Rsqr,1e-12,0.1,2,100,50.7244)
+%!test __test_sens(Rsqr,1e-12,0.1,2,10000,177.979)
+%!test __test_sens(Rsqr,1e-12,0.1,4,1,8.60838)
+%!test __test_sens(Rsqr,1e-12,0.1,4,100,44.0545)
+%!test __test_sens(Rsqr,1e-12,0.1,4,10000,150.205)

--- a/src/cw-sensitivity/private/SensitivityHoughFstatFDP.m
+++ b/src/cw-sensitivity/private/SensitivityHoughFstatFDP.m
@@ -51,7 +51,7 @@ function [pd, Ns, FDP, fdp_vars, fdp_opts] = SensitivityHoughFstatFDP(pd, Ns, ar
       error("%s: nth, pd, and Ns are not of common size", funcName);
     endif
     FAP = @(nth, Ns) falseAlarm_HoughF(nth, Ns, Fth);
-    nth = arrayfun(FAP, nth, Ns);
+    paNt = arrayfun(FAP, nth, Ns);
   endif
 
   ## variables

--- a/src/cw-sensitivity/private/SensitivitySelectStat.m
+++ b/src/cw-sensitivity/private/SensitivitySelectStat.m
@@ -20,22 +20,22 @@
 ## Calculate the false dismissal probability of a chi^2 detection statistic,
 ## such as the F-statistic
 
-function [calcPdet, calcPDF, stat_th, perSeg_th] = SensitivitySelectStat(varargin)
+function [calcPdet, calcPDF] = SensitivitySelectStat(varargin)
 
   ## options
   uvar = parseOptions(varargin,
 	       {"Nseg", "integer,strictpos,vector"},
 	       {"stat", "char","ChiSqr"},
                {"pval", "real,strictunit,matrix", []},
-               {"stat_th", "real,strictpos,matrix"},
+               {"stat_th", "real,strictpos,matrix",[]},
 	       {"perSeg_th","real,positive,matrix",0},
 	       {"dof", "integer,strictpos,scalar",4},
-	       {"mism_w", "real,vector",1}
+	       {"mism_w", "real",1} # multi-dimensional array != matrix, vector
 	      );
   Nseg = uvar.Nseg;
   stat = uvar.stat;
   pval = uvar.pval;
-  stat_th = uvar.stat_th
+  stat_th = uvar.stat_th;
   perSeg_th = uvar.perSeg_th;
   dof = uvar.dof;
   mism_w = uvar.mism_w;
@@ -72,7 +72,7 @@ function [calcPdet, calcPDF, stat_th, perSeg_th] = SensitivitySelectStat(varargi
     if cserr > 0
       error("%s: stat_th  and Nseg are not of common size", funcName);
     endif
-        switch stat
+    switch stat
       case "ChiSqr"
 	calcPdet = @(rhosqr_eff) StackSlide_cdf(Nseg, rhosqr_eff, mism_w,stat_th);
 	calcPDF = @(rhosqr_eff) StackSlide_pdf(Nseg, rhosqr_eff, mism_w,stat_th);
@@ -93,7 +93,7 @@ function Pdet = StackSlide_cdf(Nseg, rhosqr_eff, mism_w, stat_th )
   dof = 4.*Nseg;
   
   ## calculate pdf from chisquare
-  cdf = ChiSquare_cdf(stat_th , dof, Nseg.*rhosqr_eff);
+  cdf = ChiSquare_cdf(stat_th , dof, rhosqr_eff);
 
   ## integrate over mismatch
   
@@ -108,7 +108,7 @@ function PDF = StackSlide_pdf(Nseg, rhosqr_eff, mism_w, stat_th )
   dof = 4.*Nseg;
   
   ## calculate pdf from chisquare
-  pdf = ChiSquare_pdf(stat_th , dof, Nseg.*rhosqr_eff);
+  pdf = ChiSquare_pdf(stat_th , dof, rhosqr_eff);
 
   ## integrate over mismatch
   

--- a/src/cw-sensitivity/private/SensitivitySelectStat.m
+++ b/src/cw-sensitivity/private/SensitivitySelectStat.m
@@ -1,0 +1,163 @@
+## Copyright (C) 2018 Christoph Dreissigacker
+##
+## This program is free software; you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation; either version 2 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with with program; see the file COPYING. If not, write to the
+## Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+## MA  02111-1307  USA
+
+## Helper function for SensitivityDepth()
+##
+## Calculate the false dismissal probability of a chi^2 detection statistic,
+## such as the F-statistic
+
+function [calcPh0R2, stat_th, perSeg_th] = SensitivitySelectStat(Nseg, Bayesian, stat)
+
+  ## options
+  parseOptions(stat{2:end},
+               {"pval", "real,strictunit,matrix", []},
+               {"stat_th", "real,strictpos,matrix", []},
+	       {"perSeg_th","real,strictpos,matrix",0},
+              );
+  ## check if p-value or threshold is given
+  if !xor(isempty(pval), isempty(stat_th))
+    error("%s: 'pval' and 'stat_th' are mutually exclusive options", funcName);
+  endif
+  ## make inputs common size and convert p-value to threshold
+  if !isempty(pval)
+    [cserr, pval,  Nseg, perSeg_th] = common_size(pval,  Nseg, perSeg_th);
+    if cserr > 0
+      error("%s: pval and Nseg are not of common size", funcName);
+    endif
+    switch stat{1}
+      case "ChiSqr"
+	stat_th = invFalseAlarm_chi2(pval, Nseg.*4);
+	if !Bayesian
+	  calcPh0R2 = @StackSlide_cdf
+	else
+	  calcPh0R2 = @StackSlide_pdf
+	endif
+      case "HoughFstat"
+	STAT_TH = @(pval, Nseg) invFalseAlarm_HoughF(pval, Nseg, Fth);
+	stat_th = arrayfun(STAT_TH, pval, Nseg);
+	if !Bayesian
+	  calcPh0R2 = @HoughF_cdf
+	else
+	  calcPh0R2 = @HoughF_pdf
+	endif
+      otherwise
+	error("%s: invalid detection statistic '%s'", funcName, stat{1});
+    endswitch
+  else
+    [cserr, stat_th, Nseg, perSeg_th] = common_size(stat_th, Nseg, perSeg_th);
+    if cserr > 0
+      error("%s: stat_th  and Nseg are not of common size", funcName);
+    endif
+  endif
+  
+endfunction
+
+## Calculate Pdet(h_0, R^2) for the StackSlide method
+function P_h0R2 = StackSlide_cdf(Nseg, rhosqr_eff, mism_w, stat_th , perSeg_th =[] )
+
+  ## degrees of freedom
+  dof = 4.*Nseg;
+  
+  ## calculate pdf from chisquare
+  cdf = ChiSquare_cdf(stat_th , dof, Nseg.*rhosqr_eff);
+
+  ## integrate over mismatch
+  
+  Pstat_h0R2 = sum(cdf.*mism_w,5);
+  
+endfunction
+    
+## Calculate P(2F|h_0, R^2) for the StackSlide method
+function P_h0R2 = StackSlide_pdf(Nseg, rhosqr_eff, mism_w, stat_th , perSeg_th =[] )
+
+  ## degrees of freedom
+  dof = 4.*Nseg;
+  
+  ## calculate pdf from chisquare
+  pdf = ChiSquare_pdf(stat_th , dof, Nseg.*rhosqr_eff);
+
+  ## integrate over mismatch
+  
+  Pstat_h0R2 = sum(pdf.*mism_w,5);
+  
+endfunction
+
+##  Calculate Pdet(h_0, R^2) for the HoughF method
+function P_h0R2 = HoughF_cdf(Nseg, rhosqr_eff, mism_w, stat_th, perSeg_th)
+
+  ## calculate per segment cdf from chisquare
+  perSeg_cdf = ChiSquare_cdf(perSeg_th, 4, rhosqr_eff);
+
+  ## integrate over mismatch to get threshold crossing probability
+  p_th = sum(perSeg_cdf.*mism_w,5);
+
+  ## calculate binomial expression
+  nc = [0:stat_th].*ones(size(p_th));
+  pdf_h0R2 = 1./(Nseg+1).*binomialRatePDF(p_th,Nseg,nc);
+
+  ## integrate over numbercount
+  P_h0R2 = sum(pdf_h0R2,
+ 
+  
+endfunction
+
+##  Calculate P(2F|h_0, R^2) for the HoughF method
+function P_h0R2 = HoughF_pdf(Nseg, rhosqr_eff, mism_w, stat_th, perSeg_th)
+
+  ## calculate per segment cdf from chisquare
+  perSeg_cdf = ChiSquare_cdf(perSeg_th, 4, rhosqr_eff);
+
+  ## integrate over mismatch to get threshold crossing probability
+  p_th = sum(perSeg_cdf.*mism_w,5);
+
+  ## calculate binomial expression
+  Pstat_h0R2 = 1./(Nseg+1).*binomialRatePDF(p_th,Nseg,stat_val);
+  
+endfunction
+    
+function pd_rhosqr = HoughFstatFDP(pd, Ns, rhosqr, fdp_vars, fdp_opts)
+
+  ## F-statistic threshold per segment
+  Fth = fdp_opts.Fth;
+
+  ## false alarm probability per template, and number count false alarm threshold
+  paNt = fdp_vars{1};
+  nth = fdp_vars{2};
+
+  ## false dismissal probability
+  if fdp_opts.zero
+
+    ## calculate the false dismissal probability using the
+    ## zeroth-order approximation for the Hough-on-Fstat statistic
+    ## valid in the limit of N>>1 and rho<<1
+    ## this is based on Eq.(6.39) in KrishnanEtAl2004 Hough paper
+    alpha = falseAlarm_chi2 ( 2*Fth, 4 );
+    sa = erfcinv_asym(2*paNt);
+    ## Theta from Eq.(5.28) in Hough paper, dropping second term in "large N limit" (s Eq.(6.40))
+    Theta = sqrt ( Ns ./ ( 2*alpha.*(1-alpha)) );  ## + (1 - 2*alpha)./(1-alpha) .* (sa ./(2*alpha))
+    pd_rhosqr = 0.5 * erfc ( - sa + 0.25 * Theta .* exp(-Fth) .* Fth.^2 .* rhosqr );
+
+  else
+
+    ## calculate the false dismissal probability using the
+    ## exact distribution for the Hough-on-Fstat statistic
+    FDP = @(nth, Ns, rhosqr) falseDismissal_HoughF(nth, Ns, Fth, rhosqr);
+    pd_rhosqr = arrayfun(FDP, nth, Ns, rhosqr);
+
+  endif
+
+endfunction

--- a/src/statistics/ChiSquare_pdf.m
+++ b/src/statistics/ChiSquare_pdf.m
@@ -53,6 +53,10 @@ function p = ChiSquare_pdf(x, k, lambda=0)
   if any(ii(:))
     p(ii) = 0;
   endif
+  ii = isinf(lambda);
+  if any(ii(:))
+    p(ii) = 0;
+  endif
 
   ## compute the central chi^2 PDF for special case lambda==0
   ii = !isfinite(p) & (lambda == 0);


### PR DESCRIPTION
Ok, this is just a rebase of a minimally-cleaned version of Christoph's original Bayesian sensitivity estimator, not even updated documentation format yet.

We want to put this here as a reference (for the paper results) and starting point for further work:
looking over the current sensitivity-estimation machinery (mainly, the various SensitivityDepth*() functions), Christoph and I today converged on the view that it's probably a good time now for a clean re-write/re-structuring of this, given the various many extensions that have happened over time that ended up making this code pretty unreadable at this point, and also currently contain lots of code duplications.
The idea is to use the time-window between circulating the paper to P&P and final paper proofs to clean this up. We have the current implementation as a reference for comparison tests.

I'm thinking all these further patches should go onto this same branch, and then be merged to master only once this has fully converged and settled.

Reminder to self: the final code versions documentation should refer to the paper and Equation numbers therein to document what is actually being implemented here.

So, putting this "WIP" PR here only for comment and further development.

@christoph30 @kwwette 