### PR TITLE
WeaveTemplateCount.m: fix dfreq estimation to agree with Weave

### DIFF
--- a/src/cw-weave-models/WeaveTemplateCount.m
+++ b/src/cw-weave-models/WeaveTemplateCount.m
@@ -192,6 +192,14 @@ function [coh_Nt, semi_Nt, dfreq] = WeaveTemplateCount(varargin)
   coh_Nt_scale = 1.436;
   semi_Nt_scale = 1.000;
 
+  ## coordinate spacing correction factor vs 'naive' maximal coordinate distance m=g_ij dl^i dl^j (covering vs packing)
+  dim_sky = ifelse ( sky_area > 0, 2, 0 );
+  dim_fkdot = sum( fkdot_bands > 0 );
+  dim = dim_sky + dim_fkdot;
+  Rcover = LatticeCoveringRadius ( dim, lattice );
+  Rpack  = LatticePackingRadius ( dim, lattice );
+  spacing_correction = Rpack / Rcover;
+
   ## compute interpolation grid for number of templates
   coh_Nt_interp = semi_Nt_interp = dfreq_interp = zeros(length(Nsegments_interp), length(coh_Tspan_interp));
   for i = 1:length(Nsegments_interp)
@@ -219,7 +227,7 @@ function [coh_Nt, semi_Nt, dfreq] = WeaveTemplateCount(varargin)
       endfor
 
       ## compute frequency spacing
-      dfreq_interp(i, j) = 2 * sqrt(semi_max_mismatch / metrics.semi_rssky_metric.data(end, end));
+      dfreq_interp(i, j) = 2 * spacing_correction * sqrt(semi_max_mismatch / metrics.semi_rssky_metric.data(end, end));
 
     endfor
   endfor

--- a/src/lattices/AnPackingRadius.m
+++ b/src/lattices/AnPackingRadius.m
@@ -1,0 +1,40 @@
+## Copyright (C) 2019 Reinhard Prix
+##
+## This program is free software; you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation; either version 2 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with with program; see the file COPYING. If not, write to the
+## Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+## MA  02111-1307  USA
+
+## -*- texinfo -*-
+## @deftypefn {Function File} {@var{packingRadius} =} AnPackingRadius ( @var{dim} )
+##
+## Return the packing-radius for An* lattice in n dimensions,
+## from Chap.4, Eq.(79) in Conway&Sloane(1999)
+## referring to lattice-definition corresponding to the generator
+## returned by @command{AnLatticeGenerator()}, i.e. Chap.4, Eq.(76) of CS99
+##
+## @heading Note
+## can handle vector input
+##
+## @end deftypefn
+
+function packingRadius = AnPackingRadius ( dim )
+
+  packingRadius = 1/sqrt(2);
+
+  return;
+
+endfunction ## AnPackingRadius()
+
+%!assert(AnPackingRadius(1) == 1/sqrt(2))
+%!assert(AnPackingRadius(5) == 1/sqrt(2))

--- a/src/lattices/LatticePackingRadius.m
+++ b/src/lattices/LatticePackingRadius.m
@@ -1,0 +1,61 @@
+## Copyright (C) 2019 Reinhard Prix
+##
+## This program is free software; you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation; either version 2 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with with program; see the file COPYING. If not, write to the
+## Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+## MA  02111-1307  USA
+
+## -*- texinfo -*-
+## @deftypefn {Function File} {@var{R} =} LatticePackingRadius ( @var{dim}, @var{lattice} )
+##
+## return the packing radius for the given lattice
+## lattice is one of the strings @{@code{Zn}, @code{An}, @code{Ans}@}
+##
+## @heading Note
+## can handle vector input in @var{dim}
+##
+## @end deftypefn
+
+function R = LatticePackingRadius ( dim, lattice )
+
+  valid = { "Zn", "An", "Ans" };
+
+  if ( strcmp ( lattice, valid{1}) )            ## Zn
+    R = ZnPackingRadius ( dim );
+    return;
+  elseif ( strcmp ( lattice, valid{2} ) )       ## An
+    R = AnPackingRadius ( dim );
+    return;
+  elseif ( strcmp ( lattice, valid{3} ) )       ## An*
+    R = AnsPackingRadius ( dim );
+    return;
+  else
+    printf ("Unknown lattice-type, must be one of: ");
+    printf (" '%s',", valid{1:length(valid)} );
+    printf ("\n");
+    error ("Illegal input.\n");
+  endif
+
+  return;
+
+endfunction
+
+%!assert(LatticePackingRadius(1, "Zn") > 0)
+%!assert(LatticePackingRadius(1, "An") > 0)
+%!assert(LatticePackingRadius(1, "Ans") > 0)
+%!assert(LatticePackingRadius(2, "Zn") > 0)
+%!assert(LatticePackingRadius(2, "An") > 0)
+%!assert(LatticePackingRadius(2, "Ans") > 0)
+%!assert(LatticePackingRadius(3, "Zn") > 0)
+%!assert(LatticePackingRadius(3, "An") > 0)
+%!assert(LatticePackingRadius(3, "Ans") > 0)

--- a/src/lattices/ZnPackingRadius.m
+++ b/src/lattices/ZnPackingRadius.m
@@ -1,0 +1,39 @@
+## Copyright (C) 2019 Reinhard Prix
+##
+## This program is free software; you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation; either version 2 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with with program; see the file COPYING. If not, write to the
+## Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+## MA  02111-1307  USA
+
+## -*- texinfo -*-
+## @deftypefn {Function File} {@var{packingRadius} =} ZnPackingRadius ( @var{dim} )
+##
+## Return packing-radius for the Zn lattice in n dimensions
+##
+## @heading Note
+## can handle vector input
+##
+## @end deftypefn
+
+function packingRadius = ZnPackingRadius ( dim )
+
+  ## packing Radius of Zn is simply 1/2: see Chap.4,Sect.5 in Conway&Sloane(1999)
+  packingRadius = 1/2;
+
+  return;
+
+endfunction
+
+%!assert(ZnPackingRadius(1) == 1/2)
+%!assert(ZnPackingRadius(5) == 1/2)
+


### PR DESCRIPTION
- 'naive' spacing expression m=gff*dfreq^2 overestimates actual
   lattice dfreq spacing by a factor of (covering_radius/packing_radius)
results now confirmed to agree with Weave (in 5d cases we see 10-15% deviations, otherwise <1e-3).

```
Nseg lattice   sky nspin interp |      Weave    octapps     relerr
   1      Zn  true     1  false |   2.47e-07   2.47e-07   2.78e-06
   1      Zn false     1  false |   3.49e-07   3.49e-07   2.78e-06
   1     Ans  true     1  false |   3.49e-07   3.49e-07   2.78e-06
   1     Ans false     1  false |   4.27e-07   4.27e-07   2.78e-06
   1      Zn  true     2  false |   2.21e-07   2.21e-07   2.78e-06
   1      Zn false     2  false |   2.85e-07   2.85e-07   2.78e-06
   1     Ans  true     2  false |   3.23e-07   3.23e-07   2.78e-06
   1     Ans false     2  false |   3.82e-07   3.82e-07   2.78e-06
   5      Zn  true     1   true |   8.72e-07   8.71e-07   3.36e-04
   5      Zn  true     1  false |   1.23e-06   1.23e-06   3.36e-04
   5      Zn false     1   true |   1.23e-06   1.23e-06   3.36e-04
   5      Zn false     1  false |   1.74e-06   1.74e-06   3.36e-04
   5     Ans  true     1   true |   1.23e-06   1.23e-06   3.36e-04
   5     Ans  true     1  false |   1.74e-06   1.74e-06   3.36e-04
   5     Ans false     1   true |   1.51e-06   1.51e-06   3.36e-04
   5     Ans false     1  false |   2.14e-06   2.13e-06   3.36e-04
   5      Zn  true     2   true |   7.80e-07   7.79e-07   3.36e-04
   5      Zn  true     2  false |   1.10e-06   1.10e-06   3.36e-04
   5      Zn false     2   true |   1.01e-06   1.01e-06   3.36e-04
   5      Zn false     2  false |   1.42e-06   1.42e-06   3.36e-04
   5     Ans  true     2   true |   1.14e-06   1.14e-06   3.36e-04
   5     Ans  true     2  false |   1.61e-06   1.61e-06   3.36e-04
   5     Ans false     2   true |   1.35e-06   1.35e-06   3.36e-04
   5     Ans false     2  false |   1.91e-06   1.91e-06   3.36e-04
   1      Zn  true     3  false |   2.01e-07   2.21e-07  -9.54e-02
   1      Zn false     3  false |   2.47e-07   2.85e-07  -1.55e-01
   1     Ans  true     3  false |   3.02e-07   3.23e-07  -6.90e-02
   1     Ans false     3  false |   3.49e-07   3.82e-07  -9.54e-02
```
[verify_dfreq.txt](https://github.com/octapps/octapps/files/2796129/verify_dfreq.txt)

