### PR TITLE
fix test failure in amplitudeParams2Vect(): avoid psi gauge-boundaries

### DIFF
--- a/src/cw-data-analysis/amplitudeParams2Vect.m
+++ b/src/cw-data-analysis/amplitudeParams2Vect.m
@@ -64,7 +64,7 @@ function Amu = amplitudeParams2Vect ( Amp )
 endfunction ## amplitudeParams2Vect()
 
 %!test
-%!  p0 = struct("h0", 1e-24, "cosi", 0, "psi", pi/4, "phi0", pi/5);
+%!  p0 = struct("h0", 1e-24, "cosi", 0, "psi", 0.33 * pi/4, "phi0", pi/5);
 %!  p = amplitudeVect2Params(amplitudeParams2Vect(p0));
 %!  assert(p.h0, p0.h0, 1e-3);
 %!  assert(p.cosi, p0.cosi, 1e-3);


### PR DESCRIPTION
- fixes https://github.com/octapps/octapps/issues/22