### PR TITLE
fix sharedlibdeps test for non-system/Debian octave installs

### DIFF
--- a/src/condor-jobs/sharedlibdeps.m
+++ b/src/condor-jobs/sharedlibdeps.m
@@ -83,4 +83,8 @@ function deps = sharedlibdeps(varargin)
 endfunction
 
 %!test
-%!  deps = sharedlibdeps(glob(fullfile(octave_config_info("libdir"), "liboct*.so")){:});
+%!  libdir = octave_config_info("libdir");
+%!  version = octave_config_info("version");
+%!  dirs0 = glob(fullfile(libdir, "liboct*.so"));
+%!  dirs1 = glob(fullfile(libdir,"octave", version, "liboct*.so"));
+%!  deps = sharedlibdeps(dirs0{:}, dirs1{:});


### PR DESCRIPTION
noticed that on non-system/Debian installs, the 'libdir' isn't actually the full path but needs another '/octave/\<version\>/' appended. This patch allows for both possibilities now and the tests pass.