### PR TITLE
Use function DebugLevel() instead of variable debugLevel

### DIFF
--- a/src/cw-data-analysis/injectionRecoveryGCT.m
+++ b/src/cw-data-analysis/injectionRecoveryGCT.m
@@ -102,9 +102,6 @@
 ## @item GCT_binary
 ## which GCT executable to use for searching
 ##
-## @item debugLevel
-## control debug-output level
-##
 ## @item cleanup
 ## boolean: remove intermediate output files at the end or not
 ##
@@ -139,12 +136,8 @@ function results = injectionRecoveryGCT ( varargin )
                         {"Fstar0sc", "real, positive, scalar", 0},
                         {"nCand", "real,strictpos,scalar", 1 },
                         {"GCT_binary", "char", "lalapps_HierarchSearchGCT"},
-                        {"debugLevel", "real,positive,scalar", 0},
                         {"cleanup", "bool,scalar", true},
                         []);
-
-  global debugLevel;
-  debugLevel = uvar.debugLevel;
 
   ## check input consistency
   have_h0 = !isempty(uvar.inj_h0);
@@ -237,7 +230,7 @@ function results = injectionRecoveryGCT ( varargin )
   MFD.IFOs = uvar.IFOs;
   MFD.timestampsFiles = uvar.timestampsFiles;
 
-  runCode ( MFD, "lalapps_Makefakedata_v5", (uvar.debugLevel > 0) );
+  runCode ( MFD, "lalapps_Makefakedata_v5", (DebugLevel() > 0) );
   results.mfd.args = MFD;
   SFTfiles = "*.sft";
 
@@ -314,7 +307,7 @@ function results = injectionRecoveryGCT ( varargin )
     for l = 1 : Nseg
       PFS.minStartTime = tSegStart ( l );
       PFS.maxStartTime = tSegEnd ( l );
-      out = runCode ( PFS, "lalapps_PredictFstat", (uvar.debugLevel > 0) );
+      out = runCode ( PFS, "lalapps_PredictFstat", (DebugLevel() > 0) );
       pfs.twoFl(l) = str2num ( out );
     endfor ## l = 1:Nseg
 
@@ -460,7 +453,7 @@ function results = injectionRecoveryGCT ( varargin )
     endif
     GCT.loudestTwoFPerSeg = true;
 
-    runCode ( GCT, uvar.GCT_binary, (uvar.debugLevel > 0) );
+    runCode ( GCT, uvar.GCT_binary, (DebugLevel() > 0) );
 
     ## ---------- load avg-Fstat results and parse results
     DebugPrintf ( 1, "Loading GCT toplist file '%s' ... ", GCT.fnameout );
@@ -618,7 +611,7 @@ function results = injectionRecoveryGCT ( varargin )
     GCTSig.nCand1       = 1;    ## keep this many candidates in toplist
     GCTSig.loudestTwoFPerSeg = false;
 
-    runCode ( GCTSig, uvar.GCT_binary, (uvar.debugLevel > 0) );
+    runCode ( GCTSig, uvar.GCT_binary, (DebugLevel() > 0) );
 
     ## load perfect-match GCT results
     outSig = load ( GCTSig.fnameout );

--- a/src/cw-optimal-search-setup/CostFunctionsBinary.m
+++ b/src/cw-optimal-search-setup/CostFunctionsBinary.m
@@ -127,7 +127,7 @@ endfunction ## CostFunctionsBinary()
 %!  TobsMax = 360 * DAYS;
 %!  TsegMax = 10 * DAYS;
 %!
-%!  sol_v2 = OptimalSolution4StackSlide_v2 ( "costFuns", costFuns, "cost0", cost0, "TobsMax", TobsMax, "TsegMax", TsegMax, "stackparamsGuess", refParams, "debugLevel", 1, "maxiter", 3 );
+%!  sol_v2 = OptimalSolution4StackSlide_v2 ( "costFuns", costFuns, "cost0", cost0, "TobsMax", TobsMax, "TsegMax", TsegMax, "stackparamsGuess", refParams, "maxiter", 3 );
 %!
 %!  tol = -1e-2;
 %!  assert ( sol_v2.Nseg, 36, tol );
@@ -155,7 +155,7 @@ endfunction ## CostFunctionsBinary()
 %!  TobsMax = 360 * DAYS;
 %!  TsegMax = 10 * DAYS;
 %!
-%!  sol_v2 = OptimalSolution4StackSlide_v2 ( "costFuns", costFuns, "cost0", cost0, "TobsMax", TobsMax, "TsegMax", TsegMax, "stackparamsGuess", refParams, "debugLevel", 1, "maxiter", 3 );
+%!  sol_v2 = OptimalSolution4StackSlide_v2 ( "costFuns", costFuns, "cost0", cost0, "TobsMax", TobsMax, "TsegMax", TsegMax, "stackparamsGuess", refParams, "maxiter", 3 );
 %!
 %!  tol = -1e-2;
 %!  assert ( sol_v2.mCoh, 0.038235, tol );
@@ -184,7 +184,7 @@ endfunction ## CostFunctionsBinary()
 %!  TobsMax = 360 * DAYS;
 %!  TsegMax = 10 * DAYS;
 %!
-%!  sol_v2 = OptimalSolution4StackSlide_v2 ( "costFuns", costFuns, "cost0", cost0, "TobsMax", TobsMax, "TsegMax", TsegMax, "stackparamsGuess", refParams, "debugLevel", 1 );
+%!  sol_v2 = OptimalSolution4StackSlide_v2 ( "costFuns", costFuns, "cost0", cost0, "TobsMax", TobsMax, "TsegMax", TsegMax, "stackparamsGuess", refParams );
 %!
 %!  tol = -1e-2;
 %!  assert ( sol_v2.mCoh, 0.81274, tol );

--- a/src/cw-optimal-search-setup/CostFunctionsDirected.m
+++ b/src/cw-optimal-search-setup/CostFunctionsDirected.m
@@ -133,7 +133,7 @@ endfunction ## CostFunctionsDirected()
 %!  cost0 = 3.1451 * EM2014;
 %!  TobsMax = 256.49 * DAYS;
 %!
-%!  sol_v2 = OptimalSolution4StackSlide_v2 ( "costFuns", costFuns, "cost0", cost0, "TobsMax", TobsMax, "stackparamsGuess", refParams, "debugLevel", 1 );
+%!  sol_v2 = OptimalSolution4StackSlide_v2 ( "costFuns", costFuns, "cost0", cost0, "TobsMax", TobsMax, "stackparamsGuess", refParams );
 %!
 %!  tol = -1e-2;
 %!  assert ( sol_v2.mCoh, 0.11892, tol );
@@ -164,7 +164,7 @@ endfunction ## CostFunctionsDirected()
 %!  cost0 = 472 * DAYS;
 %!  TobsMax = 365 * DAYS;
 %!
-%!  sol_v2 = OptimalSolution4StackSlide_v2 ( "costFuns", costFuns, "cost0", cost0, "TobsMax", TobsMax, "stackparamsGuess", refParams, "sensApprox", "WSG", "debugLevel", 1 );
+%!  sol_v2 = OptimalSolution4StackSlide_v2 ( "costFuns", costFuns, "cost0", cost0, "TobsMax", TobsMax, "stackparamsGuess", refParams, "sensApprox", "WSG" );
 %!
 %!  tol = -1e-2;
 %!  assert ( sol_v2.mCoh, 0.19219, tol );

--- a/src/cw-optimal-search-setup/CostFunctionsEaHGCT.m
+++ b/src/cw-optimal-search-setup/CostFunctionsEaHGCT.m
@@ -252,7 +252,7 @@ endfunction ## cost_coh_wparams()
 %!  cost0 = costCoh + costInc;
 %!  TobsMax = 365 * 86400;
 %!
-%!  sol_v2 = OptimalSolution4StackSlide_v2 ( "costFuns", costFuns, "cost0", cost0, "TobsMax", TobsMax, "TsegMin", 3600, "stackparamsGuess", refParams, "debugLevel", 1 );
+%!  sol_v2 = OptimalSolution4StackSlide_v2 ( "costFuns", costFuns, "cost0", cost0, "TobsMax", TobsMax, "TsegMin", 3600, "stackparamsGuess", refParams );
 %!
 %!  tol = -1e-3;
 %!  assert ( sol_v2.mCoh, 0.14458, tol );

--- a/src/cw-optimal-search-setup/OptimalSolution4StackSlide_v2.m
+++ b/src/cw-optimal-search-setup/OptimalSolution4StackSlide_v2.m
@@ -94,9 +94,6 @@
 ## @item nonlinearMismatch
 ## use empirical nonlinear mismatch relation instead of linear @samp{mis} = xi * m
 ##
-## @item debugLevel
-## [optional] control level of debug output
-##
 ## @end table
 ##
 ## @heading Output
@@ -138,16 +135,9 @@ function sol = OptimalSolution4StackSlide_v2 ( varargin )
                         {"minMismatch", "real,positive,scalar", 0 },
                         {"sensApprox", "char", "none" },
                         {"nonlinearMismatch", "logical,scalar", false },
-                        {"debugLevel", "integer,positive,scalar", [] },
                         []);
+
   global powerEps; powerEps = 1e-5;     ## value practically considered "zero" for power-law coefficients
-  global debugLevel;
-  if ( !isempty(uvar.debugLevel) )
-    debugLevel = uvar.debugLevel;
-  endif
-  if ( isempty ( debugLevel ) )
-    debugLevel = 0;
-  endif
 
   assert( isfield( uvar.costFuns, "grid_interpolation" ) );
   assert( isfield( uvar.costFuns, "lattice" ) );

--- a/src/cw-optimal-search-setup/private/DebugPrintStackparams.m
+++ b/src/cw-optimal-search-setup/private/DebugPrintStackparams.m
@@ -15,10 +15,8 @@
 ## <http://www.gnu.org/licenses/>.
 
 function DebugPrintStackparams ( level, stackparams )
-  global debugLevel;
-  if ( isempty ( debugLevel ) ) debugLevel = 0; endif
 
-  if ( debugLevel < level )
+  if ( DebugLevel() < level )
     return;
   endif
   DAYS = 86400;

--- a/src/cw-optimal-search-setup/private/OptimalSolution4StackSlide_v2_helpers.m
+++ b/src/cw-optimal-search-setup/private/OptimalSolution4StackSlide_v2_helpers.m
@@ -75,7 +75,7 @@ endfunction ## OptimalSolution4StackSlide_v2_helpers()
 ## ==================== NON-Interpolating solvers ====================
 
 function sol = NONI_unconstrained ( stackparams, funs )
-  global debugLevel; global powerEps;
+  global powerEps;
   sol = [];
   ## ----- local shortcuts ----------
   coef = stackparams.coefInc;
@@ -120,7 +120,7 @@ function sol = NONI_unconstrained ( stackparams, funs )
               funcName, INFO, residual, OUTPUT.iterations, OUTPUT.bracketx(1), OUTPUT.bracketx(2), OUTPUT.brackety(1), OUTPUT.brackety(2) );
     catch err
       DebugPrintf ( 3, "%s: 1st fzero() clause failed: trying to find mismatch range \n", funcName );
-      if ( debugLevel >= 3 ) err, endif
+      if ( DebugLevel() >= 3 ) err, endif
       return;
     end_try_catch
     logmRange(2) = 0.95 * pole; ## stay below from pole
@@ -142,7 +142,7 @@ function sol = NONI_unconstrained ( stackparams, funs )
     mOpt = exp ( log_mOpt );
   catch err
     DebugPrintf ( 3, "%s: 2nd fzero() clause failed: trying to solve for optimal mismatch\n", funcName );
-    if ( debugLevel >= 3) err, endif
+    if ( DebugLevel() >= 3) err, endif
     return;
   end_try_catch
 
@@ -168,7 +168,7 @@ function sol = NONI_unconstrained ( stackparams, funs )
 endfunction ## NONI_unconstrained()
 
 function sol = NONI_constrainedTobs ( stackparams, funs, Tobs0 )
-  global powerEps; global debugLevel; global DAYS;
+  global powerEps; global DAYS;
   sol = [];
 
   ## ----- local shortcuts ----------
@@ -201,7 +201,7 @@ function sol = NONI_constrainedTobs ( stackparams, funs, Tobs0 )
               INFO, residual, OUTPUT.iterations, OUTPUT.bracketx(1), OUTPUT.bracketx(2), OUTPUT.brackety(1), OUTPUT.brackety(2) );
     catch err
       DebugPrintf ( 3, "%s: 1st fzero() clause failed: trying to find mismatch range \n", funcName );
-      if ( debugLevel >= 3 ) err, endif
+      if ( DebugLevel() >= 3 ) err, endif
       return;
     end_try_catch
     logmRange(2) = 0.95 * pole; ## stay below from pole
@@ -215,7 +215,7 @@ function sol = NONI_constrainedTobs ( stackparams, funs, Tobs0 )
     mOpt = exp ( logOpt );
   catch err
     DebugPrintf ( 3, "%s: 2nd fzero() clause failed: trying to solve for optimal mismatch\n", funcName );
-    if ( debugLevel >= 3) err, endif
+    if ( DebugLevel() >= 3) err, endif
     return;
   end_try_catch
 
@@ -238,7 +238,7 @@ function sol = NONI_constrainedTobs ( stackparams, funs, Tobs0 )
 endfunction ## NONI_constrainedTobs()
 
 function sol = NONI_constrainedTseg ( stackparams, funs, Tseg0 )
-  global debugLevel; global DAYS;
+  global DAYS;
   sol = [];
 
   ## ----- local shortcuts ----------
@@ -264,7 +264,7 @@ function sol = NONI_constrainedTseg ( stackparams, funs, Tseg0 )
               INFO, residual, OUTPUT.iterations, OUTPUT.bracketx(1), OUTPUT.bracketx(2), OUTPUT.brackety(1), OUTPUT.brackety(2) );
     catch err
       DebugPrintf ( 3, "%s: 1st fzero() clause failed: trying to find mismatch range\n", funcName );
-      if ( debugLevel >= 3 ) err, endif
+      if ( DebugLevel() >= 3 ) err, endif
       return;
     end_try_catch
     logmRange(2) = 0.95 * pole; ## stay below from pole
@@ -278,7 +278,7 @@ function sol = NONI_constrainedTseg ( stackparams, funs, Tseg0 )
     mOpt = exp ( logOpt );
   catch err
     DebugPrintf ( 3, "%s: 2nd fzero() clause failed: trying to find optimal mismatch\n", funcName );
-    if ( debugLevel >= 3) err, endif
+    if ( DebugLevel() >= 3) err, endif
     return;
   end_try_catch
 
@@ -303,7 +303,6 @@ function sol = NONI_constrainedTseg ( stackparams, funs, Tseg0 )
 endfunction ## NONI_constrainedTseg()
 
 function sol = NONI_constrainedTobsTseg ( stackparams, funs, Tobs0, Tseg0 )
-  global debugLevel;
 
   assert ( Tseg0 <= Tobs0 );
   sol = [];
@@ -324,7 +323,7 @@ endfunction ## NONI_constrainedTobsTseg()
 
 ## ==================== Interpolating solvers ====================
 function sol = INT_unconstrained ( stackparams, funs )
-  global debugLevel; global powerEps;
+  global powerEps;
 
   sol = [];
   ## ----- local shortcuts ----------
@@ -357,7 +356,7 @@ function sol = INT_unconstrained ( stackparams, funs )
       mIncOpt = exp(X(2));
       assert ( (mCohOpt >= 0) && (mIncOpt >= 0), "%s: fsolve() converged, but invalid negative solution {mCoh = %g, mInc = %g} < 0\n", funcName(), mCohOpt, mIncOpt );
     catch err
-      if ( debugLevel >= 3) err, endif
+      if ( DebugLevel() >= 3) err, endif
       return;
     end_try_catch
     CostCoh0 = cost0 / ( 1 + 1/crOpt );
@@ -392,7 +391,7 @@ function sol = INT_unconstrained ( stackparams, funs )
 endfunction ## INT_unconstrained()
 
 function sol = INT_constrainedTobs ( stackparams, funs, Tobs0 )
-  global powerEps; global debugLevel; global DAYS;
+  global powerEps; global DAYS;
   sol = [];
 
   ## ----- local shortcuts ----------
@@ -437,7 +436,7 @@ function sol = INT_constrainedTobs ( stackparams, funs, Tobs0 )
       mIncOpt = exp(X(2));
       assert ( (mCohOpt >= 0) && (mIncOpt >= 0), "%s: fsolve() for fixed Tobs0 converged, but invalid negative solution {mCoh = %g, mInc = %g} < 0\n", funcName(), mCohOpt, mIncOpt );
     catch err
-      if ( debugLevel >= 3 ) err, endif
+      if ( DebugLevel() >= 3 ) err, endif
       return;
     end_try_catch
 
@@ -468,7 +467,7 @@ function sol = INT_constrainedTobs ( stackparams, funs, Tobs0 )
 endfunction ## INT_constrainedTobs()
 
 function sol = INT_constrainedTseg ( stackparams, funs, Tseg0 )
-  global debugLevel; global DAYS;
+  global DAYS;
 
   sol = [];
   ## ----- local shortcuts ----------
@@ -503,7 +502,7 @@ function sol = INT_constrainedTseg ( stackparams, funs, Tseg0 )
     mIncOpt = exp(X(2));
     assert ( (mCohOpt >= 0) && (mIncOpt >= 0), "%s: fsolve() for fixed Tseg0 converged, but invalid negative solution {mCoh = %g, mInc = %g} < 0\n", funcName, mCohOpt, mIncOpt );
   catch err
-    if ( debugLevel >= 3 ) err, endif
+    if ( DebugLevel() >= 3 ) err, endif
     return;
   end_try_catch
 
@@ -527,7 +526,6 @@ function sol = INT_constrainedTseg ( stackparams, funs, Tseg0 )
 endfunction ## INT_constrainedTseg()
 
 function sol = INT_constrainedTobsTseg ( stackparams, funs, Tobs0, Tseg0 )
-  global debugLevel;
   assert ( Tseg0 <= Tobs0 );
 
   sol = [];
@@ -565,7 +563,7 @@ function sol = INT_constrainedTobsTseg ( stackparams, funs, Tobs0, Tseg0 )
     mIncOpt = exp(X(2));
     assert ( (mCohOpt >= 0) && (mIncOpt >= 0), "%s: fsolve() for fixed Tseg0+Tobs0 converged, but invalid negative solution {mCoh = %g, mInc = %g} < 0\n", funcName(), mCohOpt, mIncOpt );
   catch err
-    if ( debugLevel >= 3 ) err, endif
+    if ( DebugLevel() >= 3 ) err, endif
     return;
   end_try_catch
 
@@ -578,7 +576,6 @@ endfunction ## INT_constrainedTobsTseg()
 
 ## ==================== fully COHERENT solvers ====================
 function sol = COH_unconstrained ( stackparams, funs )
-  global debugLevel;
 
   sol = [];
   ## ----- local shortcuts ----------
@@ -601,7 +598,7 @@ function sol = COH_unconstrained ( stackparams, funs )
               "fzero() failed to find pole of denominator: INFO=%i, residual=%g, iterations=%i, mCohOpt=[%g,%g], FCN=[%g,%g]\n",
               INFO, residual, OUTPUT.iterations, OUTPUT.bracketx(1), OUTPUT.bracketx(2), OUTPUT.brackety(1), OUTPUT.brackety(2) );
     catch err
-      if ( debugLevel >= 3 ) err, endif
+      if ( DebugLevel() >= 3 ) err, endif
       return;
     end_try_catch
     logmRange(2) = 0.95 * pole; ## stay below from pole
@@ -614,7 +611,7 @@ function sol = COH_unconstrained ( stackparams, funs )
             rCoh, INFO, residual, OUTPUT.iterations, OUTPUT.bracketx(1), OUTPUT.bracketx(2), OUTPUT.brackety(1), OUTPUT.brackety(2) );
     mCohOpt = exp ( logOpt );
   catch err
-    if ( debugLevel >= 3) err, endif
+    if ( DebugLevel() >= 3) err, endif
     return;
   end_try_catch
   logTseg = (1/deltaCoh) * ( log(cost0/kCoh) + nCoh/2 * log(mCohOpt) );
@@ -648,7 +645,6 @@ endfunction ## COH_constrainedTobs()
 function stackparams = complete_stackparams ( stackparams, funs )
   ## stackparams = complete_stackparams ( stackparams, funs )
   ## fill in a number of useful 'derived' stack parameter coefficients
-  global debugLevel;
 
   ## backwards-compatilibity fix: allow 'mc' 'mf' in lieu of 'mCoh', 'mInc'
   if ( !isfield ( stackparams, "mCoh" ) && isfield ( stackparams, "mc" ) )
@@ -737,7 +733,7 @@ endfunction
 
 ## ---------- kept for temporary reference
 function sol = NONI_unconstrained_prev ( stackparams, funs )
-  global debugLevel; global powerEps;
+  global powerEps;
   sol = [];
   ## ----- local shortcuts ----------
   coef = stackparams.coefInc;
@@ -783,7 +779,7 @@ function sol = NONI_unconstrained_prev ( stackparams, funs )
               funcName, INFO, residual, OUTPUT.iterations, OUTPUT.bracketx(1), OUTPUT.bracketx(2), OUTPUT.brackety(1), OUTPUT.brackety(2) );
     catch err
       DebugPrintf ( 3, "%s: 1st fzero() clause failed: trying to find mismatch range \n", funcName );
-      if ( debugLevel >= 3 ) err, endif
+      if ( DebugLevel() >= 3 ) err, endif
       return;
     end_try_catch
     logmRange(2) = 0.95 * pole; ## stay below from pole
@@ -803,7 +799,7 @@ function sol = NONI_unconstrained_prev ( stackparams, funs )
     mNseg = exp ( log_mNseg );
   catch err
     DebugPrintf ( 3, "%s: 2nd fzero() clause failed: trying to solve for optimal mismatch (using d_N L=0)\n", funcName );
-    if ( debugLevel >= 3) err, endif
+    if ( DebugLevel() >= 3) err, endif
     return;
   end_try_catch
 
@@ -826,7 +822,7 @@ function sol = NONI_unconstrained_prev ( stackparams, funs )
     mTseg = exp ( log_mTseg );
   catch err
     DebugPrintf ( 3, "%s: 3rd fzero() clause failed: trying to solve for optimal mismatch (using d_Tseg L=0) \n", funcName );
-    if ( debugLevel >= 3) err, endif
+    if ( DebugLevel() >= 3) err, endif
     return;
   end_try_catch
 

--- a/src/general/DebugLevel.m
+++ b/src/general/DebugLevel.m
@@ -1,0 +1,54 @@
+## Copyright (C) 2022 Karl Wette, Reinhard Prix
+##
+## This program is free software; you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation; either version 2 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with Octave; see the file COPYING.  If not, see
+## <http://www.gnu.org/licenses/>.
+
+## -*- texinfo -*-
+## @deftypefn {Function File} {} DebugLevel @var{level}
+## @deftypefnx{Function File} {} DebugLevel ( @var{level} )
+## @deftypefnx{Function File} {@var{level} = } DebugLevel ( )
+##
+## Sets and/or returns the OctApps debug level @var{level}.
+##
+## @end deftypefn
+
+function varargout = DebugLevel ( level )
+
+  persistent debugLevel;
+  if ( isempty ( debugLevel ) )
+    debugLevel = 0;
+  endif
+
+  if nargin > 0
+    if ischar ( level )
+      level = str2double ( level );
+    endif
+    if !isreal ( level ) || level != round ( level ) || level < 0
+      error ( "%s: OctApps debug level must be a positive integer", funcName );
+    endif
+    debugLevel = level;
+  endif
+
+  if nargout > 0
+    varargout = { debugLevel };
+  endif
+
+endfunction ## DebugLevel()
+
+%!test
+%!  assert(DebugLevel() == 0);
+%!  DebugLevel 1;
+%!  assert(DebugLevel() == 1);
+%!  DebugLevel(2);
+%!  assert(DebugLevel() == 2);

--- a/src/general/DebugPrintf.m
+++ b/src/general/DebugPrintf.m
@@ -17,24 +17,17 @@
 ## -*- texinfo -*-
 ## @deftypefn {Function File} {} DebugPrintf ( @var{level}, @var{args}@dots{} )
 ##
-## If @var{debugLevel} >= @var{level}, then print @var{args}@dots{} using
+## If @code{DebugLevel()} >= @var{level}, then print @var{args}@dots{} using
 ## @code{fprintf()} to @file{stdout}.
-##
-## @var{debugLevel} is a global variable declared with @code{global}.
 ##
 ## @end deftypefn
 
 function DebugPrintf ( level, varargin )
-  global debugLevel;
-  if ( isempty ( debugLevel ) ) debugLevel = 0; endif
-
-  if ( debugLevel >= level )
+  if ( DebugLevel() >= level )
     fprintf ( stdout, varargin{:} );
   endif
-  return;
 endfunction ## DebugPrintf()
 
 %!test
-%!  global debugLevel;
-%!  debugLevel = 1;
+%!  DebugLevel(1);
 %!  DebugPrintf(0, "Hi there\n");


### PR DESCRIPTION
- DebugLevel() sets/returns debug level; can parse numeric or
  string input, convenient for setting from Octave command line e.g.
    octave:1> DebugLevel 1
- All other functions call DebugLevel() to get current debug level
- Can now set debug level globally rather than needing to parse as
  argument to some functions